### PR TITLE
Do not link js_of_ocaml-ppx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+-   Reduce the size of .js binaries produced by using this library by not
+    linking the ppx toolchain. (#3)
+
 ## 0.3.0
 
 -   Fix `Promise.Array.find_map` and `Promise.List.find_map` raising

--- a/dune
+++ b/dune
@@ -3,7 +3,7 @@
  (name promise)
  (js_of_ocaml
   (javascript_files indirect_promise.js))
- (libraries js_of_ocaml js_of_ocaml-ppx gen_js_api)
+ (libraries js_of_ocaml gen_js_api)
  (preprocess
   (pps js_of_ocaml-ppx))
  (modes byte))


### PR DESCRIPTION
This drastically reduces the size of .js binaries using this library.