### PR TITLE
No longer rely on `joo_global_object`

### DIFF
--- a/promise_jsoo/indirect_promise.js
+++ b/promise_jsoo/indirect_promise.js
@@ -1,25 +1,25 @@
-joo_global_object.Promise = Promise;
-
-joo_global_object.IndirectPromise = function (promise) {
-	this.underlying = promise;
-};
-
-joo_global_object.IndirectPromise.wrap = function (value) {
-	if (
-		value !== undefined &&
-		value !== null &&
-		typeof value.then === "function"
-	) {
-		return new IndirectPromise(value);
-	} else {
-		return value;
+class IndirectPromise {
+	constructor(promise) {
+		this.underlying = promise;
 	}
-};
 
-joo_global_object.IndirectPromise.unwrap = function (value) {
-	if (value instanceof joo_global_object.IndirectPromise) {
-		return value.underlying;
-	} else {
-		return value;
+	static wrap(promise) {
+		if (
+			promise !== undefined &&
+			promise !== null &&
+			typeof promise.then === "function"
+		) {
+			return new IndirectPromise(promise);
+		}
+		return promise;
 	}
-};
+
+	static unwrap(promise) {
+		if (promise instanceof globalThis.IndirectPromise) {
+			return promise.underlying;
+		}
+		return promise;
+	}
+}
+
+globalThis.IndirectPromise = IndirectPromise;


### PR DESCRIPTION
`joo_global_object` is deprecated and will result in a warning with the new release of jsoo.